### PR TITLE
Fixes for newer LyX versions, cleanup, OSX support

### DIFF
--- a/Body/biblio.lyx
+++ b/Body/biblio.lyx
@@ -137,19 +137,6 @@ bibliographystyle{plainnat}
 \end_inset
 
 
-\begin_inset ERT
-status collapsed
-
-\begin_layout Standard
-
-
-\backslash
-bibliographystyle{abbrvnat}
-\end_layout
-
-\end_inset
-
-
 \end_layout
 
 \begin_layout Standard

--- a/README.markdown
+++ b/README.markdown
@@ -10,8 +10,12 @@ Here are the instructions to get going:
 * You'll need to install the class file to your $TEXMF directory. I tried to make this as easy as possible with the cls2layout.sh script. You can run it with a simple:
 
 ``bash
-$ ./cls2layout.sh mitthesis.cls
+$ ./cls2layout.sh mitthesis.cls /my/lyx/user/directory
 ``
+
+See [the LyX documentation](https://wiki.lyx.org/LyX/UserDir) regarding the location of the LyX user directory.
+At time of writing, this is `~/.lyx` for Linux and `~/Library/Application Support/LyX-<VERSION>` for OSX.
+
 <br/>
 
 Final note: It can be done! I successfully graduated in 2017 using this template. :-) 

--- a/cls2layout.sh
+++ b/cls2layout.sh
@@ -1,25 +1,17 @@
 #!/bin/bash
 
+set -e
 
 TEXMFDIR=`kpsewhich -var-value=TEXMFHOME`
-
-CLS=`echo "$1" | tr "." "\n"`
-
-for addr in $CLS
-do
-    if [ -v $CLSNAME ]; then
-      CLSNAME=$addr
-    fi
-done
-
+CLSNAME=`basename $1 .cls`
 CLSPATH="$TEXMFDIR/tex/latex/$CLSNAME/"
 
 echo "Installing to $CLSPATH..."
 
-sudo mkdir -p $CLSPATH
-sudo cp $1 $CLSPATH
+mkdir -p $CLSPATH
+cp $1 $CLSPATH
 
-sudo texhash --verbose
+texhash --verbose
 
 echo "Creating Lyx $CLSNAME.layout file..."
 if [ -f $CLSNAME.layout ]; then
@@ -27,10 +19,11 @@ if [ -f $CLSNAME.layout ]; then
 fi
 echo "#% Do not delete the line below; configure depends on this" >> $CLSNAME.layout
 echo "#  \DeclareLaTeXClass[$CLSNAME]{$CLSNAME Style}" >> $CLSNAME.layout
-echo "\n"  >> $CLSNAME.layout
-echo "# Read the definitions from article.layout"  >> $CLSNAME.layout
-echo "Input article.layout" >> $CLSNAME.layout
+echo -e "\n"  >> $CLSNAME.layout
+echo "# Read the definitions from book.layout"  >> $CLSNAME.layout
+echo "Input book.layout" >> $CLSNAME.layout
 
-mv $CLSNAME.layout ~/.lyx/layouts
+mv $CLSNAME.layout "$2/layouts"
 
-lyx -batch -x reconfigure
+lyx -batch dummy -x reconfigure 
+

--- a/dummy.lyx
+++ b/dummy.lyx
@@ -1,0 +1,83 @@
+#LyX 2.3 created this file. For more info see http://www.lyx.org/
+\lyxformat 544
+\begin_document
+\begin_header
+\save_transient_properties true
+\origin unavailable
+\textclass article
+\use_default_options true
+\maintain_unincluded_children false
+\language english
+\language_package default
+\inputencoding auto
+\fontencoding global
+\font_roman "default" "default"
+\font_sans "default" "default"
+\font_typewriter "default" "default"
+\font_math "auto" "auto"
+\font_default_family default
+\use_non_tex_fonts false
+\font_sc false
+\font_osf false
+\font_sf_scale 100 100
+\font_tt_scale 100 100
+\use_microtype false
+\use_dash_ligatures true
+\graphics default
+\default_output_format default
+\output_sync 0
+\bibtex_command default
+\index_command default
+\paperfontsize default
+\use_hyperref false
+\papersize default
+\use_geometry false
+\use_package amsmath 1
+\use_package amssymb 1
+\use_package cancel 1
+\use_package esint 1
+\use_package mathdots 1
+\use_package mathtools 1
+\use_package mhchem 1
+\use_package stackrel 1
+\use_package stmaryrd 1
+\use_package undertilde 1
+\cite_engine basic
+\cite_engine_type default
+\use_bibtopic false
+\use_indices false
+\paperorientation portrait
+\suppress_date false
+\justification true
+\use_refstyle 1
+\use_minted 0
+\index Index
+\shortcut idx
+\color #008000
+\end_index
+\secnumdepth 3
+\tocdepth 3
+\paragraph_separation indent
+\paragraph_indentation default
+\is_math_indent 0
+\math_numbering_side default
+\quotes_style english
+\dynamic_quotes 0
+\papercolumns 1
+\papersides 1
+\paperpagestyle default
+\tracking_changes false
+\output_changes false
+\html_math_output 0
+\html_css_as_file 0
+\html_be_strict false
+\end_header
+
+\begin_body
+
+\begin_layout Standard
+
+\end_layout
+
+\end_body
+\end_document


### PR DESCRIPTION
Thanks for sharing this code. You probably don't care anymore, but I made some small updates to get things working:

* Newline instead of literal `\n` in layout file by using `echo -e`
* Remove unnecessary `sudo` usage.
* Use `set -e` to stop on first error
* Changes to support OSX (don't assume LyX user dir is `~/.lyx`; require user to supply it as second argument).
* Base off of `book.layout` instead of `article.layout` so that Chapter is available.
* Fix `biblio.lyx` in example: rm duplicate `bibliographystyle` declaration (causing errors on LyX 2.3.
* Use `basename` for portability and to simplify script
* add empty `dummy.lyx`; newer versions of LyX for some reason complain when `-batch` is used without an input file.